### PR TITLE
Set host URL for SMTP client

### DIFF
--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
@@ -137,7 +137,8 @@ namespace Serilog.Sinks.Email
                     smtpClient.UseDefaultCredentials = true;
                 else
                     smtpClient.Credentials = _connectionInfo.NetworkCredentials;
-
+                
+                smtpClient.Host = _connectionInfo.MailServer;
                 smtpClient.Port = _connectionInfo.Port;
                 smtpClient.EnableSsl = _connectionInfo.EnableSsl;
             }


### PR DESCRIPTION
I was unable to send any mail from Mandrill account and did some digging and found out the SMPTClient.Host property is never being set although it is being captured in EmailConnectionInfo.MailServer