### PR TITLE
Configuration Overload for Using system.net.mailSettings

### DIFF
--- a/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
+++ b/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
@@ -35,6 +35,43 @@ namespace Serilog
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="fromEmail">The email address emails will be sent from</param>
         /// <param name="toEmail">The email address emails will be sent to</param>
+        /// <param name="outputTemplate">A message template describing the format used to write to the sink.
+        /// the default is "{Timestamp} [{Level}] {Message}{NewLine}{Exception}".</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <returns>Logger configuration, allowing configuration to continue.</returns>
+        /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
+        public static LoggerConfiguration Email(
+            this LoggerSinkConfiguration loggerConfiguration,
+            string fromEmail,
+            string toEmail,
+            string outputTemplate = DefaultOutputTemplate,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            int batchPostingLimit = EmailSink.DefaultBatchPostingLimit,
+            TimeSpan? period = null,
+            IFormatProvider formatProvider = null)
+        {
+            if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
+            if (fromEmail == null) throw new ArgumentNullException("fromEmail");
+            if (toEmail == null) throw new ArgumentNullException("toEmail");
+
+            var connectionInfo = new EmailConnectionInfo
+            {
+                FromEmail = fromEmail,
+                ToEmail = toEmail
+            };
+
+            return Email(loggerConfiguration, connectionInfo, outputTemplate, restrictedToMinimumLevel, batchPostingLimit, period, formatProvider);
+        }
+
+        /// <summary>
+        /// Adds a sink that sends log events via email.
+        /// </summary>
+        /// <param name="loggerConfiguration">The logger configuration.</param>
+        /// <param name="fromEmail">The email address emails will be sent from</param>
+        /// <param name="toEmail">The email address emails will be sent to</param>
         /// <param name="mailServer">The SMTP email server to use</param>
         /// <param name="networkCredential">The network credentials to use to authenticate with mailServer</param>
         /// <param name="outputTemplate">A message template describing the format used to write to the sink.


### PR DESCRIPTION
As it exists currently, if you want to use the appSettings to configure the email sink, you need to provide the following keys to get it to work. 

```
    <add key="serilog:using" value="Serilog.Sinks.Email" />
    <add key="serilog:write-to:Email.toEmail" value="Errors@Whatever.com" />
    <add key="serilog:write-to:Email.fromEmail" value="Errors@Whatever.com" />
    <add key="serilog:write-to:Email.mailServer" value="localhost" />
```
Interestingly, if you leave the mailServer key blank (""), it will use one in system.net.mailSettings from your config file. This change makes it so that you only need to provide toEmail and fromEmail, since our typical config behavior is to provide these keys in every app that needs to send email:

```
  <system.net>
    <mailSettings>
      <smtp deliveryMethod="Network" from="NoReply@Whatever.com">
        <network host="localhost" port="25" />
      </smtp>
    </mailSettings>
  </system.net>
```