### PR TITLE
Make EmailSink public

### DIFF
--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
@@ -137,8 +137,7 @@ namespace Serilog.Sinks.Email
                     smtpClient.UseDefaultCredentials = true;
                 else
                     smtpClient.Credentials = _connectionInfo.NetworkCredentials;
-                
-                smtpClient.Host = _connectionInfo.MailServer;
+
                 smtpClient.Port = _connectionInfo.Port;
                 smtpClient.EnableSsl = _connectionInfo.EnableSsl;
             }

--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
@@ -25,7 +25,7 @@ using Serilog.Sinks.PeriodicBatching;
 
 namespace Serilog.Sinks.Email
 {
-    public class EmailSink : PeriodicBatchingSink
+    class EmailSink : PeriodicBatchingSink
     {
         readonly EmailConnectionInfo _connectionInfo;
 

--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
@@ -25,7 +25,7 @@ using Serilog.Sinks.PeriodicBatching;
 
 namespace Serilog.Sinks.Email
 {
-    class EmailSink : PeriodicBatchingSink
+    public class EmailSink : PeriodicBatchingSink
     {
         readonly EmailConnectionInfo _connectionInfo;
 


### PR DESCRIPTION
This at least allows it to be created with a custom ITextFormatter from a client project which will include all custom properties on the even to also be included in the email.