### PR TITLE
Allow ITextFormatter and Is Email Body HTML override.

### DIFF
--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
@@ -137,8 +137,7 @@ namespace Serilog.Sinks.Email
                     smtpClient.UseDefaultCredentials = true;
                 else
                     smtpClient.Credentials = _connectionInfo.NetworkCredentials;
-                
-                smtpClient.Host = _connectionInfo.MailServer;
+
                 smtpClient.Port = _connectionInfo.Port;
                 smtpClient.EnableSsl = _connectionInfo.EnableSsl;
             }

--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
@@ -25,7 +25,7 @@ using Serilog.Sinks.PeriodicBatching;
 
 namespace Serilog.Sinks.Email
 {
-    public class EmailSink : PeriodicBatchingSink
+    class EmailSink : PeriodicBatchingSink
     {
         readonly EmailConnectionInfo _connectionInfo;
 

--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
@@ -25,7 +25,7 @@ using Serilog.Sinks.PeriodicBatching;
 
 namespace Serilog.Sinks.Email
 {
-    class EmailSink : PeriodicBatchingSink
+    public class EmailSink : PeriodicBatchingSink
     {
         readonly EmailConnectionInfo _connectionInfo;
 


### PR DESCRIPTION
Added new overload to create EmailSink with custom ITextFormatter and added IsBodyHtml to EmailConnectionInfo.

These were to allow the full Serilog details to be written into the email, including the custom properties which had been added.