### PR TITLE
Allow ITextFormatter and Is Email Body HTML override (2nd Attempt)

### DIFF
--- a/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
+++ b/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
@@ -205,6 +205,7 @@ namespace Serilog
             TimeSpan? period = null)
         {
             if (connectionInfo == null) throw new ArgumentNullException("connectionInfo");
+            if (textFormatter == null) throw new ArgumentNullException("textFormatter");
 
             var defaultedPeriod = period ?? EmailSink.DefaultPeriod;
 

--- a/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
+++ b/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Serilog Contributors
+// Copyright 2014 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ using Serilog.Configuration;
 using Serilog.Events;
 using Serilog.Formatting.Display;
 using Serilog.Sinks.Email;
+using Serilog.Formatting;
 
 namespace Serilog
 {
@@ -181,6 +182,34 @@ namespace Serilog
 
             return loggerConfiguration.Sink(
                 new EmailSink(connectionInfo, batchPostingLimit, defaultedPeriod, formatter),
+                restrictedToMinimumLevel);
+        }
+
+        /// <summary>
+        /// Adds a sink that sends log events via email.
+        /// </summary>
+        /// <param name="loggerConfiguration">The logger configuration.</param>
+        /// <param name="connectionInfo">The connection info used for </param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
+        /// <param name="textFormatter">ITextFormatter implementation to write log entry to email.</param>
+        /// <returns>Logger configuration, allowing configuration to continue.</returns>
+        /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
+        public static LoggerConfiguration Email(
+            this LoggerSinkConfiguration loggerConfiguration,
+            EmailConnectionInfo connectionInfo,
+            ITextFormatter textFormatter,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            int batchPostingLimit = EmailSink.DefaultBatchPostingLimit,
+            TimeSpan? period = null)
+        {
+            if (connectionInfo == null) throw new ArgumentNullException("connectionInfo");
+
+            var defaultedPeriod = period ?? EmailSink.DefaultPeriod;
+
+            return loggerConfiguration.Sink(
+                new EmailSink(connectionInfo, batchPostingLimit, defaultedPeriod, textFormatter),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailConnectionInfo.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailConnectionInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Serilog Contributors
+// Copyright 2014 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ namespace Serilog.Sinks.Email
         {
             Port = DefaultPort;
             EmailSubject = DefaultSubject;
+            IsBodyHtml = false;
         }
 
         /// <summary>
@@ -78,5 +79,10 @@ namespace Serilog.Sinks.Email
         /// The SMTP email server to use.
         /// </summary>
         public string MailServer { get; set; }
+
+        /// <summary>
+        /// Sets whether the body contents of the email is HTML. Defaults to false.
+        /// </summary>
+        public bool IsBodyHtml { get; set; }
     }
 }

--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Serilog Contributors
+// Copyright 2014 Serilog Contributors
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -117,7 +117,8 @@ namespace Serilog.Sinks.Email
                 Subject = _connectionInfo.EmailSubject,
                 Body = payload.ToString(),
                 BodyEncoding = Encoding.UTF8,
-                SubjectEncoding = Encoding.UTF8
+                SubjectEncoding = Encoding.UTF8,
+                IsBodyHtml = _connectionInfo.IsBodyHtml
             };
 
             foreach (var recipient in _connectionInfo.ToEmail.Split(",;".ToCharArray(), StringSplitOptions.RemoveEmptyEntries))


### PR DESCRIPTION
Added new overload to create EmailSink with custom ITextFormatter and added IsBodyHtml to EmailConnectionInfo.

These were to allow the full Serilog details to be written into the email, including the custom properties which had been added.