### PR TITLE
Support .NET Framework 40

### DIFF
--- a/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
+++ b/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
@@ -11,27 +11,28 @@
     <AssemblyName>Serilog.Sinks.Email</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>bin\$(TargetFrameworkVersion)\$(Configuration)</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DocumentationFile>bin\Debug\Serilog.Sinks.Email.XML</DocumentationFile>
+    <DocumentationFile>bin\$(TargetFrameworkVersion)\$(Configuration)\Serilog.Sinks.Email.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>bin\$(TargetFrameworkVersion)\$(Configuration)</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DocumentationFile>bin\Release\Serilog.Sinks.Email.XML</DocumentationFile>
+    <DocumentationFile>bin\$(TargetFrameworkVersion)\$(Configuration)\Serilog.Sinks.Email.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -39,16 +40,32 @@
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>..\..\assets\Serilog.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <DefineConstants Condition=" !$(DefineConstants.Contains(';NET')) ">$(DefineConstants);$(TargetFrameworkVersion.Replace("v", "NET").Replace(".", ""))</DefineConstants>
+    <DefineConstants Condition=" $(DefineConstants.Contains(';NET')) ">$(DefineConstants.Remove($(DefineConstants.LastIndexOf(";NET"))));$(TargetFrameworkVersion.Replace("v", "NET").Replace(".", ""))</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Serilog">
-      <HintPath>..\..\packages\Serilog.1.4.204\lib\net45\Serilog.dll</HintPath>
-    </Reference>
-    <Reference Include="Serilog.FullNetFx">
-      <HintPath>..\..\packages\Serilog.1.4.204\lib\net45\Serilog.FullNetFx.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL" Condition=" '$(TargetFrameworkVersion)' == 'v4.0' ">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Serilog.1.5.11\lib\net40\Serilog.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL" Condition=" '$(TargetFrameworkVersion)' == 'v4.0' ">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Serilog.1.5.11\lib\net40\Serilog.FullNetFx.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL" Condition=" '$(TargetFrameworkVersion)' == 'v4.5' ">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Serilog.1.5.11\lib\net45\Serilog.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL" Condition=" '$(TargetFrameworkVersion)' == 'v4.5' ">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Serilog.1.5.11\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="LoggerConfigurationEmailExtensions.cs" />
@@ -64,7 +81,19 @@
       <Link>Serilog.snk</Link>
     </None>
     <None Include="packages.config" />
-    <None Include="Serilog.Sinks.Email.nuspec" />
+    <None Include="Serilog.Sinks.Email.nuspec">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Target Name="AfterBuild">
+    <MSBuild Condition=" '$(TargetFrameworkVersion.Replace(&quot;v&quot;,&quot;&quot;))' &gt;= '4.5' " Projects="$(MSBuildProjectFile)" Properties="TargetFrameworkVersion=v4.0" RunEachTargetSeparately="true" />
+  </Target>
 </Project>

--- a/src/Serilog.Sinks.Email/Serilog.Sinks.Email.nuspec
+++ b/src/Serilog.Sinks.Email/Serilog.Sinks.Email.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
     <tags>serilog logging email smtp</tags>
     <dependencies>
-      <dependency id="Serilog" version="1.5.11" />
+      <dependency id="Serilog" version="[1.5.11,2)" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Serilog.Sinks.Email/Serilog.Sinks.Email.nuspec
+++ b/src/Serilog.Sinks.Email/Serilog.Sinks.Email.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>http://serilog.net/images/serilog-sink-nuget.png</iconUrl>
     <tags>serilog logging email smtp</tags>
     <dependencies>
-      <dependency id="Serilog" version="[1.4.204,2)" />
+      <dependency id="Serilog" version="1.5.11" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Serilog.Sinks.Email/Serilog.Sinks.Email.nuspec
+++ b/src/Serilog.Sinks.Email/Serilog.Sinks.Email.nuspec
@@ -14,4 +14,9 @@
       <dependency id="Serilog" version="[1.4.204,2)" />
     </dependencies>
   </metadata>
+  <files>
+    <file src="bin\v4.0\$configuration$\$id$.dll" target="lib\net40\" />
+    <file src="bin\v4.0\$configuration$\$id$.xml" target="lib\net40\" />
+    <file src="bin\v4.0\$configuration$\$id$.pdb" target="lib\net40\" />
+  </files>
 </package>

--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
@@ -93,6 +93,36 @@ namespace Serilog.Sinks.Email
                 _smtpClient.Dispose();
         }
 
+        protected override void EmitBatch(IEnumerable<LogEvent> events)
+        {
+            if (events == null)
+                throw new ArgumentNullException("events");
+            var payload = new StringWriter();
+
+            foreach (var logEvent in events)
+            {
+                _textFormatter.Format(logEvent, payload);
+            }
+
+            var mailMessage = new MailMessage
+            {
+                From = new MailAddress(_connectionInfo.FromEmail),
+                Subject = _connectionInfo.EmailSubject,
+                Body = payload.ToString(),
+                BodyEncoding = Encoding.UTF8,
+                SubjectEncoding = Encoding.UTF8,
+                IsBodyHtml = _connectionInfo.IsBodyHtml
+            };
+
+            foreach (var recipient in _connectionInfo.ToEmail.Split(",;".ToCharArray(), StringSplitOptions.RemoveEmptyEntries))
+            {
+                mailMessage.To.Add(recipient);
+            }
+
+            _smtpClient.Send(mailMessage);
+        }
+
+#if NET45
         /// <summary>
         /// Emit a batch of log events, running asynchronously.
         /// </summary>
@@ -128,6 +158,7 @@ namespace Serilog.Sinks.Email
 
             await _smtpClient.SendMailAsync(mailMessage);
         }
+#endif
 
         private SmtpClient CreateSmtpClient()
         {
@@ -146,6 +177,5 @@ namespace Serilog.Sinks.Email
 
             return smtpClient;
         }
-
     }
 }

--- a/src/Serilog.Sinks.Email/packages.config
+++ b/src/Serilog.Sinks.Email/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Serilog" version="1.5.11" targetFramework="net40" />
+  <package id="Serilog" version="1.5.11" targetFramework="net45" />
 </packages>

--- a/src/Serilog.Sinks.Email/packages.config
+++ b/src/Serilog.Sinks.Email/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Serilog" version="1.4.204" targetFramework="net45" />
+  <package id="Serilog" version="1.5.11" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
I had a need to use Serilog on a project limited to the .NET Framework 4.0 at the present time.  Recently I encountered some mechanisms to make managing multiple target framework versions easier to manage through changes to the MSBuild project files.  

I have implemented a synchronous version of the functionality in the .NET Framework 4.0 and updated the associated build pieces to now output v4.0 and v4.5 assemblies.  Thoughts and constructive criticism and feedback are expected. :-)  

Suggestions on the best way to handle execution of the sink asynchronously in the 4.0 Framework are welcome.  Suggestions I discussed with others so far are BCL support for async / await.  I'm not experienced in that so at this point this is the best I've got.