### PR TITLE
added rate limiting to prevent log mail spamming

### DIFF
--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailConnectionInfo.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailConnectionInfo.cs
@@ -84,5 +84,12 @@ namespace Serilog.Sinks.Email
         /// Sets whether the body contents of the email is HTML. Defaults to false.
         /// </summary>
         public bool IsBodyHtml { get; set; }
+
+        /// <summary>
+        /// Limits the maximum number of emails per hour (60 minute moving time window).
+        /// 
+        /// Null (Default) will disable rate limiting.
+        /// </summary>
+        public int? MaxNumberOfSentMailsPerHour { get; set; }
     }
 }


### PR DESCRIPTION
this change allows to optionally set a limit to how many emails may be sent by the email sink in a given time window of 60 minutes. 

the default is "null" which will disable rate limiting and therefor existing code will not change in behavior.

I did extract method on Emit()/EmitAsync() to deduplicate the code.
