### PR TITLE
Mailkit needs to authenticate after connect

### DIFF
--- a/src/Serilog.Sinks.Email/Sinks/Email/MailKitEmailSink.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/MailKitEmailSink.cs
@@ -122,6 +122,10 @@ namespace Serilog.Sinks.Email
             var smtpClient = new SmtpClient();
             if (!string.IsNullOrWhiteSpace(_connectionInfo.MailServer))
             {
+                smtpClient.Connect(
+                    _connectionInfo.MailServer, _connectionInfo.Port,
+                    useSsl: _connectionInfo.EnableSsl);
+
                 if (_connectionInfo.NetworkCredentials != null)
                 {
                     smtpClient.Authenticate(
@@ -129,10 +133,6 @@ namespace Serilog.Sinks.Email
                         _connectionInfo.NetworkCredentials.GetCredential(
                             _connectionInfo.MailServer, _connectionInfo.Port, "smtp"));
                 }
-
-                smtpClient.Connect(
-                    _connectionInfo.MailServer, _connectionInfo.Port,
-                    useSsl: _connectionInfo.EnableSsl); 
             }
             return smtpClient;
         }


### PR DESCRIPTION
This will hopefully fix the error reported in #21:

> It shows the following error:
2016-11-22T20:59:43.7592606Z Failed to send email: MailKit.ServiceNotConnectedException: The SmtpClient must be connected before you can authenticate. at MailKit.Net.Smtp.SmtpClient.Authenticate(Encoding encoding, ICredentials credentials, CancellationToken cancellationToken) at Serilog.Sinks.Email.EmailSink.OpenConnectedSmtpClient() at Serilog.Sinks.Email.EmailSink.<EmitBatchAsync>d__8.MoveNext()

> I am using the following initialization code for the sink:
`
new LoggerConfiguration()
.MinimumLevel.Debug()
.Enrich.FromLogContext()
.WriteTo.Email(
toEmail: loggerConfig.GetValue("Mail:MailTo"),
mailSubject: loggerConfig.GetValue("Mail:MailSubject"),
fromEmail: mailConfig.GetValue("MailFrom"),
mailServer: mailConfig.GetValue("MailServer"),
networkCredential: ParseCred(mailConfig.GetValue("MailCredentials"))
).CreateLogger();`
```