### PR TITLE
Added subject templating

### DIFF
--- a/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
+++ b/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
@@ -42,7 +42,7 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="mailSubject">The subject used in error mails, can be a plain string or a template such as {Timestamp} [{Level}] occurred...</param>
+        /// <param name="mailSubject">The subject, can be a plain string or a template such as {Timestamp} [{Level}] occurred.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Email(
@@ -84,7 +84,7 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="mailSubject">The subject used in error mails</param>
+        /// <param name="mailSubject">The subject, can be a plain string or a template such as {Timestamp} [{Level}] occurred.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Email(
@@ -130,7 +130,7 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="mailSubject">The subject used in error mails</param>
+        /// <param name="mailSubject">The subject, can be a plain string or a template such as {Timestamp} [{Level}] occurred.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Email(
@@ -173,7 +173,7 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="mailSubject">The subject used in error mails</param>
+        /// <param name="mailSubject">The subject, can be a plain string or a template such as {Timestamp} [{Level}] occurred.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Email(
@@ -211,7 +211,7 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="textFormatter">ITextFormatter implementation to write log entry to email.</param>
-        /// <param name="mailSubjectFormatter">The subject used in error mails</param>
+        /// <param name="mailSubject">The subject, can be a plain string or a template such as {Timestamp} [{Level}] occurred.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Email(
@@ -221,13 +221,12 @@ namespace Serilog
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             int batchPostingLimit = EmailSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
-            ITextFormatter mailSubjectFormatter = null)
+            string mailSubject = EmailConnectionInfo.DefaultSubject)
         {
             if (connectionInfo == null) throw new ArgumentNullException("connectionInfo");
             if (textFormatter == null) throw new ArgumentNullException("textFormatter");
 
-            if (mailSubjectFormatter == null)
-                mailSubjectFormatter = new MessageTemplateTextFormatter(EmailConnectionInfo.DefaultSubject, null);
+            ITextFormatter mailSubjectFormatter = new MessageTemplateTextFormatter(mailSubject, null);
 
             var defaultedPeriod = period ?? EmailSink.DefaultPeriod;
 

--- a/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
+++ b/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
@@ -42,7 +42,7 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="mailSubject">The subject used in error mails</param>
+        /// <param name="mailSubject">The subject used in error mails, can be a plain string or a template such as {Timestamp} [{Level}] occurred...</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Email(
@@ -188,11 +188,17 @@ namespace Serilog
         {
             if (connectionInfo == null) throw new ArgumentNullException("connectionInfo");
 
+            if (!string.IsNullOrEmpty(connectionInfo.EmailSubject))
+            {
+                mailSubject = connectionInfo.EmailSubject;
+            }
+
             var defaultedPeriod = period ?? EmailSink.DefaultPeriod;
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
+            var subjectLineFormatter = new MessageTemplateTextFormatter(mailSubject, formatProvider);
 
             return loggerConfiguration.Sink(
-                new EmailSink(connectionInfo, batchPostingLimit, defaultedPeriod, formatter),
+                new EmailSink(connectionInfo, batchPostingLimit, defaultedPeriod, formatter, subjectLineFormatter),
                 restrictedToMinimumLevel);
         }
 
@@ -205,7 +211,7 @@ namespace Serilog
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="textFormatter">ITextFormatter implementation to write log entry to email.</param>
-        /// <param name="mailSubject">The subject used in error mails</param>
+        /// <param name="mailSubjectFormatter">The subject used in error mails</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Email(
@@ -215,15 +221,18 @@ namespace Serilog
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             int batchPostingLimit = EmailSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
-            string mailSubject = EmailConnectionInfo.DefaultSubject)
+            ITextFormatter mailSubjectFormatter = null)
         {
             if (connectionInfo == null) throw new ArgumentNullException("connectionInfo");
             if (textFormatter == null) throw new ArgumentNullException("textFormatter");
 
+            if (mailSubjectFormatter == null)
+                mailSubjectFormatter = new MessageTemplateTextFormatter(EmailConnectionInfo.DefaultSubject, null);
+
             var defaultedPeriod = period ?? EmailSink.DefaultPeriod;
 
             return loggerConfiguration.Sink(
-                new EmailSink(connectionInfo, batchPostingLimit, defaultedPeriod, textFormatter),
+                new EmailSink(connectionInfo, batchPostingLimit, defaultedPeriod, textFormatter, mailSubjectFormatter),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailConnectionInfo.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailConnectionInfo.cs
@@ -65,7 +65,7 @@ namespace Serilog.Sinks.Email
         public string ToEmail { get; set; }
 
         /// <summary>
-        /// The subject to use for the email, this can be a template
+        /// The subject to use for the email, this can be a template.
         /// </summary>
         [DefaultValue(DefaultSubject)]
         public string EmailSubject { get; set; }

--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailConnectionInfo.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailConnectionInfo.cs
@@ -65,7 +65,7 @@ namespace Serilog.Sinks.Email
         public string ToEmail { get; set; }
 
         /// <summary>
-        /// The subject to use for the email.
+        /// The subject to use for the email, this can be a template
         /// </summary>
         [DefaultValue(DefaultSubject)]
         public string EmailSubject { get; set; }

--- a/test/Serilog.Sinks.Email.Tests/project.json
+++ b/test/Serilog.Sinks.Email.Tests/project.json
@@ -33,7 +33,7 @@
           "dependencies": {
               "Microsoft.NETCore.App": {
                   "type": "platform",
-                  "version": "1.0.0"
+                  "version": "1.1.0"
               },
               "System.Linq": "4.1.0",
               "System.Threading": "4.0.11"

--- a/test/Serilog.Sinks.Email.Tests/project.json
+++ b/test/Serilog.Sinks.Email.Tests/project.json
@@ -31,7 +31,10 @@
               "portable-net45+win8"
           ],
           "dependencies": {
-            "Microsoft.NETCore.App": "1.0.0",
+            "Microsoft.NETCore.App": {
+                "type": "platform",
+                "version": "1.0.0"
+              },
               "System.Linq": "4.1.0",
               "System.Threading": "4.0.11"
           }

--- a/test/Serilog.Sinks.Email.Tests/project.json
+++ b/test/Serilog.Sinks.Email.Tests/project.json
@@ -31,10 +31,7 @@
               "portable-net45+win8"
           ],
           "dependencies": {
-              "Microsoft.NETCore.App": {
-                  "type": "platform",
-                  "version": "1.1.0"
-              },
+            "Microsoft.NETCore.App": "1.0.0",
               "System.Linq": "4.1.0",
               "System.Threading": "4.0.11"
           }


### PR DESCRIPTION
The subject line now works similarly to the message content, rather than being a static string, it can now contain templated areas such as {Level}, {MachineName} and any of the other placeholders.