### PR TITLE
Allow disabling MailKit server certificate validation

### DIFF
--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailConnectionInfo.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailConnectionInfo.cs
@@ -75,6 +75,16 @@ namespace Serilog.Sinks.Email
         /// </summary>
         public bool EnableSsl { get; set; }
 
+#if MAIL_KIT
+        /// <summary>
+        /// Flag as true to disable SSL server certificate validation. Use
+        /// with cuation. This only works on `netstandard1.3`. If you
+        /// are targeting `net45`, you can use
+        /// `System.Net.ServicePointManager.ServerCertificateValidationCallback`.
+        /// </summary>
+        public bool DisableServerCertificateValidation { get; set; }
+#endif
+
         /// <summary>
         /// The SMTP email server to use.
         /// </summary>

--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailConnectionInfo.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailConnectionInfo.cs
@@ -75,15 +75,16 @@ namespace Serilog.Sinks.Email
         /// </summary>
         public bool EnableSsl { get; set; }
 
-#if MAIL_KIT
         /// <summary>
-        /// Flag as true to disable SSL server certificate validation. Use
-        /// with cuation. This only works on `netstandard1.3`. If you
-        /// are targeting `net45`, you can use
-        /// `System.Net.ServicePointManager.ServerCertificateValidationCallback`.
+        /// Provides a method that validates server certificates.
         /// </summary>
-        public bool DisableServerCertificateValidation { get; set; }
-#endif
+        /// <remarks>
+        /// This only works on `netstandard1.3` with `MailKit`. If you
+        /// are targeting `net45`+, you should add your validation to 
+        /// `System.Net.ServicePointManager.ServerCertificateValidationCallback`
+        /// manually.
+        /// </remarks>
+        public System.Net.Security.RemoteCertificateValidationCallback ServerCertificateValidationCallback { get; set; }
 
         /// <summary>
         /// The SMTP email server to use.

--- a/src/Serilog.Sinks.Email/Sinks/Email/MailKitEmailSink.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/MailKitEmailSink.cs
@@ -130,10 +130,9 @@ namespace Serilog.Sinks.Email
             var smtpClient = new SmtpClient();
             if (!string.IsNullOrWhiteSpace(_connectionInfo.MailServer))
             {
-                if (_connectionInfo.DisableServerCertificateValidation)
+                if (_connectionInfo.ServerCertificateValidationCallback != null)
                 {
-                    smtpClient.ServerCertificateValidationCallback +=
-                        (sender, certificate, chain, sslPolicyErrors) => true;
+                    smtpClient.ServerCertificateValidationCallback += _connectionInfo.ServerCertificateValidationCallback;
                 }
 
                 smtpClient.Connect(

--- a/src/Serilog.Sinks.Email/Sinks/Email/MailKitEmailSink.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/MailKitEmailSink.cs
@@ -130,6 +130,12 @@ namespace Serilog.Sinks.Email
             var smtpClient = new SmtpClient();
             if (!string.IsNullOrWhiteSpace(_connectionInfo.MailServer))
             {
+                if (_connectionInfo.DisableServerCertificateValidation)
+                {
+                    smtpClient.ServerCertificateValidationCallback +=
+                        (sender, certificate, chain, sslPolicyErrors) => true;
+                }
+
                 smtpClient.Connect(
                     _connectionInfo.MailServer, _connectionInfo.Port,
                     useSsl: _connectionInfo.EnableSsl);

--- a/src/Serilog.Sinks.Email/project.json
+++ b/src/Serilog.Sinks.Email/project.json
@@ -29,7 +29,8 @@
       "dependencies": {
         "MailKit": "1.4.2",
         "System.Linq": "4.1.0",
-        "System.Threading": "4.0.11"
+        "System.Threading": "4.0.11",
+        "System.Net.Security": "4.0.0"
       },
       "buildOptions": {
         "define": [


### PR DESCRIPTION
This fixes #30.

This is not great, because `EmailConnectionInfo.DisableServerCertificateValidation` only exists when targeting >= `netstandard1.3`.

I did this because, AFAICT, we should probably not try to modify the shared [`ServicePointManager.ServerCertificateValidationCallback` Property](https://msdn.microsoft.com/en-us/library/system.net.servicepointmanager.servercertificatevalidationcallback(v=vs.110).aspx) when targeting >= `net45` (aka full windows framework via `System.Net.Mail.SmtpClient`). It seems like modifying such an important shared security-sensitive property based on a flag passed to the logger configuration is a bad idea.

I'm open to suggestions on a better way to do this.

