### PR TITLE
Adding ServerCertificateValidationCallback Option

### DIFF
--- a/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
+++ b/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
@@ -20,6 +20,7 @@ using Serilog.Events;
 using Serilog.Formatting.Display;
 using Serilog.Sinks.Email;
 using Serilog.Formatting;
+using System.Net.Security;
 
 namespace Serilog
 {
@@ -43,6 +44,7 @@ namespace Serilog
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="mailSubject">The subject, can be a plain string or a template such as {Timestamp} [{Level}] occurred.</param>
+        /// <param name="serverCertificateValidationCallback">Option to add callback for certificate validation on client Connect</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Email(
@@ -54,7 +56,8 @@ namespace Serilog
             int batchPostingLimit = EmailSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
-            string mailSubject = EmailConnectionInfo.DefaultSubject)
+            string mailSubject = EmailConnectionInfo.DefaultSubject,
+            RemoteCertificateValidationCallback serverCertificateValidationCallback = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (fromEmail == null) throw new ArgumentNullException("fromEmail");
@@ -64,7 +67,8 @@ namespace Serilog
             {
                 FromEmail = fromEmail,
                 ToEmail = toEmail,
-                EmailSubject = mailSubject
+                EmailSubject = mailSubject,
+                ServerCertificateValidationCallback = serverCertificateValidationCallback
             };
 
             return Email(loggerConfiguration, connectionInfo, outputTemplate, restrictedToMinimumLevel, batchPostingLimit, period, formatProvider);
@@ -85,6 +89,7 @@ namespace Serilog
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="mailSubject">The subject, can be a plain string or a template such as {Timestamp} [{Level}] occurred.</param>
+        /// <param name="serverCertificateValidationCallback">Option to add callback for certificate validation on client Connect</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Email(
@@ -98,7 +103,8 @@ namespace Serilog
             int batchPostingLimit = EmailSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
-            string mailSubject = EmailConnectionInfo.DefaultSubject)
+            string mailSubject = EmailConnectionInfo.DefaultSubject,
+            RemoteCertificateValidationCallback serverCertificateValidationCallback = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (fromEmail == null) throw new ArgumentNullException("fromEmail");
@@ -110,7 +116,8 @@ namespace Serilog
                 ToEmail = toEmail,
                 MailServer = mailServer,
                 NetworkCredentials = networkCredential,
-                EmailSubject = mailSubject
+                EmailSubject = mailSubject,
+                ServerCertificateValidationCallback = serverCertificateValidationCallback
             };
 
             return Email(loggerConfiguration, connectionInfo, outputTemplate, restrictedToMinimumLevel, batchPostingLimit, period, formatProvider);
@@ -131,6 +138,7 @@ namespace Serilog
         /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="mailSubject">The subject, can be a plain string or a template such as {Timestamp} [{Level}] occurred.</param>
+        /// <param name="serverCertificateValidationCallback">Option to add callback for certificate validation on client Connect</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration Email(
@@ -144,19 +152,21 @@ namespace Serilog
             int batchPostingLimit = EmailSink.DefaultBatchPostingLimit,
             TimeSpan? period = null,
             IFormatProvider formatProvider = null,
-            string mailSubject = EmailConnectionInfo.DefaultSubject)
+            string mailSubject = EmailConnectionInfo.DefaultSubject,
+            RemoteCertificateValidationCallback serverCertificateValidationCallback = null)
         {
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (fromEmail == null) throw new ArgumentNullException("fromEmail");
             if (toEmails == null) throw new ArgumentNullException("toEmails");
-            
+
             var connectionInfo = new EmailConnectionInfo
             {
                 FromEmail = fromEmail,
                 ToEmail = string.Join(";", toEmails),
                 MailServer = mailServer,
                 NetworkCredentials = networkCredential,
-                EmailSubject = mailSubject
+                EmailSubject = mailSubject,
+                ServerCertificateValidationCallback = serverCertificateValidationCallback
             };
 
             return Email(loggerConfiguration, connectionInfo, outputTemplate, restrictedToMinimumLevel, batchPostingLimit, period, formatProvider, mailSubject);


### PR DESCRIPTION
I would like to include the option to add the callback which is already checked in OpenConnectedSmtpClient().  The calling code would be able to have something like this to make sure that even default exchange setups work.

```
private bool ValidationCallback(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
{
	if (sslPolicyErrors == SslPolicyErrors.None)
		return true;

	// if there are errors in the certificate chain, look at each error to determine the cause.
	if ((sslPolicyErrors & SslPolicyErrors.RemoteCertificateChainErrors) != 0 || (sslPolicyErrors & SslPolicyErrors.RemoteCertificateNameMismatch) != 0)
	{
		if (chain != null && chain.ChainStatus != null)
		{
			foreach (var status in chain.ChainStatus)
			{
				if ((certificate.Subject == certificate.Issuer) && (status.Status == X509ChainStatusFlags.UntrustedRoot))
				{
					// self-signed certificates with an untrusted root are valid. 
					continue;
				}
				else if (status.Status != X509ChainStatusFlags.NoError)
				{
					// if there are any other errors in the certificate chain, the certificate is invalid,
					// so the method returns false.
					return false;
				}
			}
		}

		// When processing reaches this line, the only errors in the certificate chain are 
		// untrusted root errors for self-signed certificates. These certificates are valid
		// for default Exchange server installations, so return true.
		return true;
	}

	return false;
}
```

Reference Callback Solution for Calling Code
https://github.com/jstedfast/MailKit/issues/307#issuecomment-191860617
Reference  
#37 