### PR TITLE
Add extension as alternative for ICredentialsByHost

### DIFF
--- a/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
+++ b/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
@@ -115,6 +115,61 @@ namespace Serilog
 
             return Email(loggerConfiguration, connectionInfo, outputTemplate, restrictedToMinimumLevel, batchPostingLimit, period, formatProvider);
         }
+        
+        /// <summary>
+        /// Adds a sink that sends log events via email.
+        /// </summary>
+        /// <param name="loggerConfiguration">The logger configuration.</param>
+        /// <param name="fromEmail">The email address emails will be sent from</param>
+        /// <param name="toEmail">The email address emails will be sent to</param>
+        /// <param name="mailServer">The SMTP email server to use</param>
+        /// <param name="port">The port of the mailServer</param>
+        /// <param name="username">The username to use to authenticate with mailServer</param>
+        /// <param name="password">The password to use to authenticate with mailServer</param>
+        /// <param name="outputTemplate">A message template describing the format used to write to the sink.
+        /// the default is "{Timestamp} [{Level}] {Message}{NewLine}{Exception}".</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
+        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
+        /// <param name="period">The time to wait between checking for event batches.</param>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <param name="mailSubject">The subject, can be a plain string or a template such as {Timestamp} [{Level}] occurred.</param>
+        /// <returns>Logger configuration, allowing configuration to continue.</returns>
+        /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
+		public static LoggerConfiguration Email(
+            this LoggerSinkConfiguration loggerConfiguration,
+            string fromEmail,
+            string toEmail,
+            string mailServer,
+            int port = 25,
+            string username = null,
+            string password = null,
+            string outputTemplate = DefaultOutputTemplate,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            int batchPostingLimit = EmailSink.DefaultBatchPostingLimit,
+            TimeSpan? period = null,
+            IFormatProvider formatProvider = null,
+            string mailSubject = EmailConnectionInfo.DefaultSubject)
+        {
+            if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
+            if (fromEmail == null) throw new ArgumentNullException("fromEmail");
+            if (toEmail == null) throw new ArgumentNullException("toEmail");
+
+            NetworkCredential networkCredential = null;
+            if (!string.IsNullOrWhiteSpace(username) && !string.IsNullOrWhiteSpace(password))
+                networkCredential = new NetworkCredential(username, password);
+
+            var connectionInfo = new EmailConnectionInfo
+            {
+                FromEmail = fromEmail,
+                ToEmail = toEmail,
+                MailServer = mailServer,
+                Port = port,
+                NetworkCredentials = networkCredential,
+                EmailSubject = mailSubject
+            };
+
+            return Email(loggerConfiguration, connectionInfo, outputTemplate, restrictedToMinimumLevel, batchPostingLimit, period, formatProvider);
+        }
 
         /// <summary>
         /// Adds a sink that sends log events via email.

--- a/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
+++ b/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
@@ -123,9 +123,9 @@ namespace Serilog
         /// <param name="fromEmail">The email address emails will be sent from</param>
         /// <param name="toEmail">The email address emails will be sent to</param>
         /// <param name="mailServer">The SMTP email server to use</param>
-        /// <param name="port">The port of the mailServer</param>
         /// <param name="username">The username to use to authenticate with mailServer</param>
         /// <param name="password">The password to use to authenticate with mailServer</param>
+        /// <param name="port">The port of the mailServer</param>
         /// <param name="outputTemplate">A message template describing the format used to write to the sink.
         /// the default is "{Timestamp} [{Level}] {Message}{NewLine}{Exception}".</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
@@ -140,9 +140,9 @@ namespace Serilog
             string fromEmail,
             string toEmail,
             string mailServer,
+            string username,
+            string password,
             int port = 25,
-            string username = null,
-            string password = null,
             string outputTemplate = DefaultOutputTemplate,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             int batchPostingLimit = EmailSink.DefaultBatchPostingLimit,


### PR DESCRIPTION
Add extension with port, username and password parameters so they can be used from the configuration:
<add key="serilog:write-to:Email.port" value="25" />
<add key="serilog:write-to:Email.username" value="John" />
<add key="serilog:write-to:Email.password" value="iamjohn" />

This is a fix for #58 