### PR TITLE
Update referencies: Mailkit, Linq and Threading

### DIFF
--- a/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
+++ b/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
@@ -44,9 +44,9 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="MailKit" Version="1.4.2" />
-    <PackageReference Include="System.Linq" Version="4.1.0" />
-    <PackageReference Include="System.Threading" Version="4.0.11" />
+    <PackageReference Include="MailKit" Version="2.1.4" />
+    <PackageReference Include="System.Linq" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
+++ b/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>The file sink for Serilog support TLS 1.2</Description>
-    <VersionPrefix>2.3.1-TLS-1.2</VersionPrefix>
+    <Description>The file sink for Serilog</Description>
+    <VersionPrefix>2.3.1</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -10,12 +10,12 @@
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <PackageId>Serilog.Sinks.Email.TLS1.2</PackageId>
+    <PackageId>Serilog.Sinks.Email</PackageId>
     <PackageTags>serilog;file;io</PackageTags>
     <PackageIconUrl>http://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
     <PackageProjectUrl>http://serilog.net</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
-    <RepositoryUrl>https://github.com/mmarzullo/serilog-sinks-email-tls1.2</RepositoryUrl>
+    <RepositoryUrl>https://github.com/serilog/serilog-sinks-email</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>

--- a/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
+++ b/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>The file sink for Serilog support TLS 1.2</Description>
-    <VersionPrefix>2.3.1.1</VersionPrefix>
+    <VersionPrefix>2.3.1-TLS-1.2</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
+++ b/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
@@ -10,7 +10,7 @@
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <PackageId>Serilog.Sinks.Email</PackageId>
+    <PackageId>Serilog.Sinks.Email.MailKit-v2.1.4</PackageId>
     <PackageTags>serilog;file;io</PackageTags>
     <PackageIconUrl>http://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
     <PackageProjectUrl>http://serilog.net</PackageProjectUrl>

--- a/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
+++ b/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>The file sink for Serilog</Description>
+    <Description>The file sink for Serilog support TLS 1.2</Description>
     <VersionPrefix>2.3.1</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
@@ -15,7 +15,7 @@
     <PackageIconUrl>http://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
     <PackageProjectUrl>http://serilog.net</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
-    <RepositoryUrl>https://github.com/serilog/serilog-sinks-email</RepositoryUrl>
+    <RepositoryUrl>https://github.com/mmarzullo/serilog-sinks-email-tls1.2</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>

--- a/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
+++ b/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>The file sink for Serilog support TLS 1.2</Description>
-    <VersionPrefix>2.3.1</VersionPrefix>
+    <VersionPrefix>2.3.1.1</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
+++ b/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
@@ -10,7 +10,7 @@
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <PackageId>Serilog.Sinks.Email.MailKit-v2.1.4</PackageId>
+    <PackageId>Serilog.Sinks.Email.TLS1.2</PackageId>
     <PackageTags>serilog;file;io</PackageTags>
     <PackageIconUrl>http://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
     <PackageProjectUrl>http://serilog.net</PackageProjectUrl>


### PR DESCRIPTION
The version of the _Mailkit_ that is using _Serilog.Sinks.Email_ library is not compatible with _TLS 1.2_ on _NetStandard_. Based on the release notes of the _Mailkit_ library it started to be compatible with _TLS1.2_ on version _1.22.0_ (2017-11-24) and the latest official version of _Serilog.Sinks.Email_ is referencing to _Mailkit 1.4.2_ (2016-08-14).
**Update references:**
* MailKit - Version: 1.4.2 to 2.1.4
* System.Linq - Version: 4.0.11 to 4.3.0
* System.Threading - Version: 4.1.0 to 4.3.0