### PR TITLE
Re-implement sink using IBatchedLogEventSink

### DIFF
--- a/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
+++ b/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
@@ -39,8 +39,6 @@ namespace Serilog
         /// <param name="outputTemplate">A message template describing the format used to write to the sink.
         /// the default is "{Timestamp} [{Level}] {Message}{NewLine}{Exception}".</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
-        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
-        /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="mailSubject">The subject, can be a plain string or a template such as {Timestamp} [{Level}] occurred.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
@@ -51,8 +49,6 @@ namespace Serilog
             string toEmail,
             string outputTemplate = DefaultOutputTemplate,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            int batchPostingLimit = EmailSink.DefaultBatchPostingLimit,
-            TimeSpan? period = null,
             IFormatProvider formatProvider = null,
             string mailSubject = EmailConnectionInfo.DefaultSubject)
         {
@@ -67,7 +63,7 @@ namespace Serilog
                 EmailSubject = mailSubject
             };
 
-            return Email(loggerConfiguration, connectionInfo, outputTemplate, restrictedToMinimumLevel, batchPostingLimit, period, formatProvider);
+            return Email(loggerConfiguration, connectionInfo, outputTemplate, restrictedToMinimumLevel, formatProvider);
         }
 
         /// <summary>
@@ -81,8 +77,6 @@ namespace Serilog
         /// <param name="outputTemplate">A message template describing the format used to write to the sink.
         /// the default is "{Timestamp} [{Level}] {Message}{NewLine}{Exception}".</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
-        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
-        /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="mailSubject">The subject, can be a plain string or a template such as {Timestamp} [{Level}] occurred.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
@@ -95,8 +89,6 @@ namespace Serilog
             ICredentialsByHost networkCredential = null,
             string outputTemplate = DefaultOutputTemplate,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            int batchPostingLimit = EmailSink.DefaultBatchPostingLimit,
-            TimeSpan? period = null,
             IFormatProvider formatProvider = null,
             string mailSubject = EmailConnectionInfo.DefaultSubject)
         {
@@ -113,7 +105,7 @@ namespace Serilog
                 EmailSubject = mailSubject
             };
 
-            return Email(loggerConfiguration, connectionInfo, outputTemplate, restrictedToMinimumLevel, batchPostingLimit, period, formatProvider);
+            return Email(loggerConfiguration, connectionInfo, outputTemplate, restrictedToMinimumLevel, formatProvider);
         }
 
         /// <summary>
@@ -127,8 +119,6 @@ namespace Serilog
         /// <param name="outputTemplate">A message template describing the format used to write to the sink.
         /// the default is "{Timestamp} [{Level}] {Message}{NewLine}{Exception}".</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
-        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
-        /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="mailSubject">The subject, can be a plain string or a template such as {Timestamp} [{Level}] occurred.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
@@ -141,8 +131,6 @@ namespace Serilog
             ICredentialsByHost networkCredential = null,
             string outputTemplate = DefaultOutputTemplate,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            int batchPostingLimit = EmailSink.DefaultBatchPostingLimit,
-            TimeSpan? period = null,
             IFormatProvider formatProvider = null,
             string mailSubject = EmailConnectionInfo.DefaultSubject)
         {
@@ -159,7 +147,7 @@ namespace Serilog
                 EmailSubject = mailSubject
             };
 
-            return Email(loggerConfiguration, connectionInfo, outputTemplate, restrictedToMinimumLevel, batchPostingLimit, period, formatProvider, mailSubject);
+            return Email(loggerConfiguration, connectionInfo, outputTemplate, restrictedToMinimumLevel, formatProvider, mailSubject);
         }
 
         /// <summary>
@@ -170,8 +158,6 @@ namespace Serilog
         /// <param name="outputTemplate">A message template describing the format used to write to the sink.
         /// the default is "{Timestamp} [{Level}] {Message}{NewLine}{Exception}".</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
-        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
-        /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
         /// <param name="mailSubject">The subject, can be a plain string or a template such as {Timestamp} [{Level}] occurred.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
@@ -181,8 +167,6 @@ namespace Serilog
             EmailConnectionInfo connectionInfo,
             string outputTemplate = DefaultOutputTemplate,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            int batchPostingLimit = EmailSink.DefaultBatchPostingLimit,
-            TimeSpan? period = null,
             IFormatProvider formatProvider = null,
             string mailSubject = EmailConnectionInfo.DefaultSubject)
         {
@@ -193,12 +177,11 @@ namespace Serilog
                 mailSubject = connectionInfo.EmailSubject;
             }
 
-            var defaultedPeriod = period ?? EmailSink.DefaultPeriod;
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
             var subjectLineFormatter = new MessageTemplateTextFormatter(mailSubject, formatProvider);
 
             return loggerConfiguration.Sink(
-                new EmailSink(connectionInfo, batchPostingLimit, defaultedPeriod, formatter, subjectLineFormatter),
+                new EmailSink(connectionInfo, formatter, subjectLineFormatter),
                 restrictedToMinimumLevel);
         }
 
@@ -208,8 +191,6 @@ namespace Serilog
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="connectionInfo">The connection info used for </param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
-        /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
-        /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="textFormatter">ITextFormatter implementation to write log entry to email.</param>
         /// <param name="mailSubject">The subject, can be a plain string or a template such as {Timestamp} [{Level}] occurred.</param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
@@ -219,8 +200,6 @@ namespace Serilog
             EmailConnectionInfo connectionInfo,
             ITextFormatter textFormatter,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            int batchPostingLimit = EmailSink.DefaultBatchPostingLimit,
-            TimeSpan? period = null,
             string mailSubject = EmailConnectionInfo.DefaultSubject)
         {
             if (connectionInfo == null) throw new ArgumentNullException("connectionInfo");
@@ -228,10 +207,8 @@ namespace Serilog
 
             ITextFormatter mailSubjectFormatter = new MessageTemplateTextFormatter(mailSubject, null);
 
-            var defaultedPeriod = period ?? EmailSink.DefaultPeriod;
-
             return loggerConfiguration.Sink(
-                new EmailSink(connectionInfo, batchPostingLimit, defaultedPeriod, textFormatter, mailSubjectFormatter),
+                new EmailSink(connectionInfo, textFormatter, mailSubjectFormatter),
                 restrictedToMinimumLevel);
         }
     }

--- a/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
+++ b/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.0.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.2.0" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.0-dev-00765" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
+++ b/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.0.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.0.0" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
+++ b/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.0.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.0-dev-00765" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
@@ -19,6 +19,7 @@ using System.IO;
 using System.Net.Mail;
 using System.Text;
 using System.Threading.Tasks;
+using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Formatting;
@@ -28,7 +29,7 @@ using System.Linq;
 
 namespace Serilog.Sinks.Email
 {
-    class EmailSink : PeriodicBatchingSink
+    class EmailSink : IBatchedLogEventSink, ILogEventSink, IDisposable
     {
         readonly EmailConnectionInfo _connectionInfo;
 
@@ -38,27 +39,15 @@ namespace Serilog.Sinks.Email
 
         readonly ITextFormatter _subjectLineFormatter;
 
-        /// <summary>
-        /// A reasonable default for the number of events posted in
-        /// each batch.
-        /// </summary>
-        public const int DefaultBatchPostingLimit = 100;
-
-        /// <summary>
-        /// A reasonable default time to wait between checking for event batches.
-        /// </summary>
-        public static readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(30);
+        private static Task CompletedTask = Task.FromResult(false); // The value is irrelevant as it just marks a completed operation.
 
         /// <summary>
         /// Construct a sink emailing with the specified details.
         /// </summary>
         /// <param name="connectionInfo">Connection information used to construct the SMTP client and mail messages.</param>
-        /// <param name="batchSizeLimit">The maximum number of events to post in a single batch.</param>
-        /// <param name="period">The time to wait between checking for event batches.</param>
         /// <param name="textFormatter">Supplies culture-specific formatting information, or null.</param>
         /// <param name="subjectLineFormatter">Supplies culture-specific formatting information, or null.</param>
-        public EmailSink(EmailConnectionInfo connectionInfo, int batchSizeLimit, TimeSpan period, ITextFormatter textFormatter, ITextFormatter subjectLineFormatter)
-            : base(batchSizeLimit, period)
+        public EmailSink(EmailConnectionInfo connectionInfo, ITextFormatter textFormatter, ITextFormatter subjectLineFormatter)
         {
             if (connectionInfo == null) throw new ArgumentNullException(nameof(connectionInfo));
 
@@ -89,24 +78,37 @@ namespace Serilog.Sinks.Email
         /// <summary>
         /// Free resources held by the sink.
         /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Free resources held by the sink.
+        /// </summary>
         /// <param name="disposing">If true, called because the object is being disposed; if false,
         /// the object is being disposed from the finalizer.</param>
-        protected override void Dispose(bool disposing)
+        protected virtual void Dispose(bool disposing)
         {
-            // First flush the buffer
-            base.Dispose(disposing);
-
             if (disposing)
                 _smtpClient.Dispose();
+        }
+
+        /// <summary>
+        /// Emit the provided log event to the sink.
+        /// </summary>
+        /// <param name="logEvent">The log event to write.</param>
+        public void Emit(LogEvent logEvent)
+        {
+            SelfLog.WriteLine("The email sink only supports batched log events.");
         }
 
         /// <summary>
         /// Emit a batch of log events, running asynchronously.
         /// </summary>
         /// <param name="events">The events to emit.</param>
-        /// <remarks>Override either <see cref="PeriodicBatchingSink.EmitBatch"/> or <see cref="PeriodicBatchingSink.EmitBatchAsync"/>,
-        /// not both.</remarks>
-        protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
+        public async Task EmitBatchAsync(IEnumerable<LogEvent> events)
         {
             if (events == null)
                 throw new ArgumentNullException(nameof(events));
@@ -137,6 +139,16 @@ namespace Serilog.Sinks.Email
             }
 
             await _smtpClient.SendMailAsync(mailMessage);
+        }
+
+        /// <summary>
+        /// Allows sinks to perform periodic work without requiring additional threads
+        /// or timers (thus avoiding additional flush/shut-down complexity).
+        /// </summary>
+        /// <returns></returns>
+        public Task OnEmptyBatchAsync()
+        {
+            return CompletedTask;
         }
 
         private SmtpClient CreateSmtpClient()

--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
@@ -101,7 +101,7 @@ namespace Serilog.Sinks.Email
         /// <param name="logEvent">The log event to write.</param>
         public void Emit(LogEvent logEvent)
         {
-            SelfLog.WriteLine("The email sink only supports batched log events.");
+            Task.Run(() => EmitBatchAsync(new [] { logEvent }));
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.Email/Sinks/Email/MailKitEmailSink.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/MailKitEmailSink.cs
@@ -83,7 +83,7 @@ namespace Serilog.Sinks.Email
         /// <param name="logEvent">The log event to write.</param>
         public void Emit(LogEvent logEvent)
         {
-            SelfLog.WriteLine("The email sink only supports batched log events.");
+            Task.Run(() => EmitBatchAsync(new [] { logEvent }));
         }
 
         /// <summary>


### PR DESCRIPTION
Solves #77. This is a semver-major breaking change that allows the email sink to be used with alternative batching algorithms, rather than just the current PeriodicBatchingSink.