### PR TITLE
Added EmailSubject null/empty check to overload

### DIFF
--- a/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
+++ b/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
@@ -264,6 +264,11 @@ namespace Serilog
         {
             if (connectionInfo == null) throw new ArgumentNullException("connectionInfo");
             if (textFormatter == null) throw new ArgumentNullException("textFormatter");
+            
+            if (!string.IsNullOrEmpty(connectionInfo.EmailSubject))
+            {
+                mailSubject = connectionInfo.EmailSubject;
+            }
 
             ITextFormatter mailSubjectFormatter = new MessageTemplateTextFormatter(mailSubject, null);
 


### PR DESCRIPTION
One of the EmailConnectionInfo overloads was not doing a null or empty check on mailSubject, so it was using the default subject instead of the one provided in connectionInfo.