### PR TITLE
Introduce a new IBatchTextFormatter for handling batches of log events

### DIFF
--- a/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
+++ b/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
@@ -241,8 +241,7 @@ namespace Serilog
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="connectionInfo">The connection info used for</param>
-        /// <param name="textFormatter">The <see cref="ITextFormatter"/> implementation to write log entries to email.
-        /// Writes a header and/or a footer if the text formatter also implements the <see cref="IBatchTextFormatter"/> interface.</param>
+        /// <param name="textFormatter">The <see cref="ITextFormatter"/> or <see cref="IBatchTextFormatter"/> implementation to write log entries to email.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>

--- a/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
+++ b/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
@@ -1,11 +1,11 @@
 // Copyright 2014 Serilog Contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -173,7 +173,7 @@ namespace Serilog
             if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (fromEmail == null) throw new ArgumentNullException("fromEmail");
             if (toEmails == null) throw new ArgumentNullException("toEmails");
-            
+
             var connectionInfo = new EmailConnectionInfo
             {
                 FromEmail = fromEmail,

--- a/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
+++ b/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
@@ -241,7 +241,8 @@ namespace Serilog
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="connectionInfo">The connection info used for</param>
-        /// <param name="textFormatter">The <see cref="ITextFormatter"/> or <see cref="IBatchTextFormatter"/> implementation to write log entries to email.</param>
+        /// <param name="textFormatter">The <see cref="ITextFormatter"/> implementation to write log entries to email.
+        /// Writes a header and/or a footer if the text formatter also implements the <see cref="IBatchTextFormatter"/> interface.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>

--- a/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
+++ b/src/Serilog.Sinks.Email/LoggerConfigurationEmailExtensions.cs
@@ -241,7 +241,7 @@ namespace Serilog
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="connectionInfo">The connection info used for</param>
-        /// <param name="textFormatter">ITextFormatter implementation to write log entry to email.</param>
+        /// <param name="textFormatter">The <see cref="ITextFormatter"/> or <see cref="IBatchTextFormatter"/> implementation to write log entries to email.</param>
         /// <param name="restrictedToMinimumLevel">The minimum log event level required in order to write an event to the sink.</param>
         /// <param name="batchPostingLimit">The maximum number of events to post in a single batch.</param>
         /// <param name="period">The time to wait between checking for event batches.</param>

--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
@@ -63,10 +63,13 @@ namespace Serilog.Sinks.Email
 
             var payload = new StringWriter();
 
+            var batchTextFormatter = _textFormatter as IBatchTextFormatter;
+            batchTextFormatter?.WriteHeader(payload);
             foreach (var logEvent in events)
             {
                 _textFormatter.Format(logEvent, payload);
             }
+            batchTextFormatter?.WriteFooter(payload);
 
             var subject = new StringWriter();
             _subjectLineFormatter.Format(events.OrderByDescending(e => e.Level).First(), subject);

--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
@@ -1,11 +1,11 @@
 // Copyright 2014 Serilog Contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,7 +49,7 @@ namespace Serilog.Sinks.Email
             _textFormatter = textFormatter;
             _subjectLineFormatter = subjectLineFormatter;
         }
-        
+
         /// <summary>
         /// Emit a batch of log events, running asynchronously.
         /// </summary>

--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
@@ -63,13 +63,17 @@ namespace Serilog.Sinks.Email
 
             var payload = new StringWriter();
 
-            var batchTextFormatter = _textFormatter as IBatchTextFormatter;
-            batchTextFormatter?.WriteHeader(payload);
-            foreach (var logEvent in events)
+            if (_textFormatter is IBatchTextFormatter batchTextFormatter)
             {
-                _textFormatter.Format(logEvent, payload);
+                batchTextFormatter.FormatBatch(events, payload);
             }
-            batchTextFormatter?.WriteFooter(payload);
+            else
+            {
+                foreach (var logEvent in events)
+                {
+                    _textFormatter.Format(logEvent, payload);
+                }
+            }
 
             var subject = new StringWriter();
             _subjectLineFormatter.Format(events.OrderByDescending(e => e.Level).First(), subject);

--- a/src/Serilog.Sinks.Email/Sinks/Email/IBatchTextFormatter.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/IBatchTextFormatter.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using Serilog.Configuration;
+using Serilog.Events;
+using Serilog.Formatting;
+
+namespace Serilog.Sinks.Email
+{
+    /// <summary>
+    /// An extension of <see cref="ITextFormatter"/> for handling batches of log events.
+    /// <para/>
+    /// Use this interface if you need to write a header and/or a footer before/after formatting a batch of log events.
+    /// This is useful if you want to format log events inside a table of an html email.
+    /// Use <see cref="WriteHeader"/> to write the opening tags (e.g. <c>&lt;html&gt;&lt;body&gt;&lt;table&gt;</c>)
+    /// and <see cref="WriteFooter"/> to write the closing tags (e.g. <c>&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</c>).
+    /// <para/>
+    /// Pass an <see cref="IBatchTextFormatter"/> instance for the <see cref="ITextFormatter"/> argument when configuring the email sink with
+    /// <see cref="Serilog.LoggerConfigurationEmailExtensions.Email(LoggerSinkConfiguration,EmailConnectionInfo,ITextFormatter,LogEventLevel,int,TimeSpan?,string)"/>.
+    /// </summary>
+    public interface IBatchTextFormatter : ITextFormatter
+    {
+        /// <summary>
+        /// Use this method to write a header just before a batch of log events is written to the <paramref name="output"/>.
+        /// <para/>
+        /// For example, write the opening tags (e.g. <c>&lt;html&gt;&lt;body&gt;&lt;table&gt;</c>) for an html email.
+        /// </summary>
+        /// <param name="output">The output where to write the header.</param>
+        void WriteHeader(TextWriter output);
+
+        /// <summary>
+        /// Use this method to write a footer just after a batch of log events is written to the <paramref name="output"/>.
+        /// <para/>
+        /// For example, write the closing tags (e.g. <c>&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</c>) for an html email.
+        /// </summary>
+        /// <param name="output">The output where to write the footer.</param>
+        void WriteFooter(TextWriter output);
+    }
+}

--- a/src/Serilog.Sinks.Email/Sinks/Email/IBatchTextFormatter.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/IBatchTextFormatter.cs
@@ -7,17 +7,17 @@ using Serilog.Formatting;
 namespace Serilog.Sinks.Email
 {
     /// <summary>
-    /// An extension of <see cref="ITextFormatter"/> for handling batches of log events.
+    /// Writes a header and a footer when handling batches of log events.
     /// <para/>
     /// Use this interface if you need to write a header and/or a footer before/after formatting a batch of log events.
     /// This is useful if you want to format log events inside a table of an html email.
     /// Use <see cref="WriteHeader"/> to write the opening tags (e.g. <c>&lt;html&gt;&lt;body&gt;&lt;table&gt;</c>)
     /// and <see cref="WriteFooter"/> to write the closing tags (e.g. <c>&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</c>).
     /// <para/>
-    /// Pass an <see cref="IBatchTextFormatter"/> instance for the <see cref="ITextFormatter"/> argument when configuring the email sink with
-    /// <see cref="Serilog.LoggerConfigurationEmailExtensions.Email(LoggerSinkConfiguration,EmailConnectionInfo,ITextFormatter,LogEventLevel,int,TimeSpan?,string)"/>.
+    /// Make the text formatter passed to <see cref="Serilog.LoggerConfigurationEmailExtensions.Email(LoggerSinkConfiguration,EmailConnectionInfo,ITextFormatter,LogEventLevel,int,TimeSpan?,string)"/>
+    /// also implement the <see cref="IBatchTextFormatter"/> interface in order to write a header and a footer to the same output as the <see cref="ITextFormatter"/>.
     /// </summary>
-    public interface IBatchTextFormatter : ITextFormatter
+    public interface IBatchTextFormatter
     {
         /// <summary>
         /// Use this method to write a header just before a batch of log events is written to the <paramref name="output"/>.

--- a/src/Serilog.Sinks.Email/Sinks/Email/IBatchTextFormatter.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/IBatchTextFormatter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Serilog.Configuration;
 using Serilog.Events;
@@ -7,32 +8,46 @@ using Serilog.Formatting;
 namespace Serilog.Sinks.Email
 {
     /// <summary>
-    /// Writes a header and a footer when handling batches of log events.
+    /// An extension of <see cref="ITextFormatter"/> for handling batches of log events.
+    /// Use this interface when more control over the formatting of multiple log events is required.
     /// <para/>
-    /// Use this interface if you need to write a header and/or a footer before/after formatting a batch of log events.
-    /// This is useful if you want to format log events inside a table of an html email.
-    /// Use <see cref="WriteHeader"/> to write the opening tags (e.g. <c>&lt;html&gt;&lt;body&gt;&lt;table&gt;</c>)
-    /// and <see cref="WriteFooter"/> to write the closing tags (e.g. <c>&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</c>).
-    /// <para/>
-    /// Make the text formatter passed to <see cref="Serilog.LoggerConfigurationEmailExtensions.Email(LoggerSinkConfiguration,EmailConnectionInfo,ITextFormatter,LogEventLevel,int,TimeSpan?,string)"/>
-    /// also implement the <see cref="IBatchTextFormatter"/> interface in order to write a header and a footer to the same output as the <see cref="ITextFormatter"/>.
+    /// Pass an <see cref="IBatchTextFormatter"/> instance for the <see cref="ITextFormatter"/> argument when configuring the email sink with
+    /// <see cref="Serilog.LoggerConfigurationEmailExtensions.Email(LoggerSinkConfiguration,EmailConnectionInfo,ITextFormatter,LogEventLevel,int,TimeSpan?,string)"/>.
+    /// <example>
+    /// This interface might be used to write a header and/or a footer before/after formatting multiple log events,
+    /// for example to format the events inside a table of an html email. It could also be used to group events by log level.
+    /// <para>
+    /// <code>
+    /// class HtmlTableFormatter : IBatchTextFormatter
+    /// {
+    ///     public void FormatBatch(IEnumerable&lt;LogEvent&gt; logEvents, TextWriter output)
+    ///     {
+    ///         output.Write("&lt;table&gt;");
+    ///         foreach (var logEvent in logEvents)
+    ///         {
+    ///             Format(logEvent, output);
+    ///         }
+    ///         output.Write("&lt;/table&gt;");
+    ///     }
+    ///
+    ///     public void Format(LogEvent logEvent, TextWriter output)
+    ///     {
+    ///         output.Write("&lt;tr&gt;");
+    ///         using var buffer = new StringWriter();
+    ///         logEvent.RenderMessage(buffer);
+    ///         output.Write(WebUtility.HtmlEncode(buffer.ToString()));
+    ///         output.Write("&lt;/tr&gt;");
+    ///     }
+    /// }
+    /// </code>
+    /// </para>
+    /// </example>
     /// </summary>
-    public interface IBatchTextFormatter
+    public interface IBatchTextFormatter : ITextFormatter
     {
-        /// <summary>
-        /// Use this method to write a header just before a batch of log events is written to the <paramref name="output"/>.
-        /// <para/>
-        /// For example, write the opening tags (e.g. <c>&lt;html&gt;&lt;body&gt;&lt;table&gt;</c>) for an html email.
-        /// </summary>
-        /// <param name="output">The output where to write the header.</param>
-        void WriteHeader(TextWriter output);
-
-        /// <summary>
-        /// Use this method to write a footer just after a batch of log events is written to the <paramref name="output"/>.
-        /// <para/>
-        /// For example, write the closing tags (e.g. <c>&lt;/table&gt;&lt;/body&gt;&lt;/html&gt;</c>) for an html email.
-        /// </summary>
-        /// <param name="output">The output where to write the footer.</param>
-        void WriteFooter(TextWriter output);
+        /// <summary>Format the log events into the output.</summary>
+        /// <param name="logEvents">The events to format.</param>
+        /// <param name="output">The output.</param>
+        void FormatBatch(IEnumerable<LogEvent> logEvents, TextWriter output);
     }
 }


### PR DESCRIPTION
This is useful if you want to format log events inside a table of an html email for example.

This new interface allows you to write a header, e.g. `<html><body><table>` before writing a batch of log events and a footer, e.g. `</table></body></html>`after the batch of log events is written.