### PR TITLE
Modifying MailKit on non-SSL connections to pass in SecureSocketOptions.None

### DIFF
--- a/src/Serilog.Sinks.Email/Sinks/Email/MailKitEmailTransport.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/MailKitEmailTransport.cs
@@ -57,9 +57,18 @@ namespace Serilog.Sinks.Email
                     smtpClient.ServerCertificateValidationCallback += _connectionInfo.ServerCertificateValidationCallback;
                 }
 
-                smtpClient.Connect(
-                    _connectionInfo.MailServer, _connectionInfo.Port,
-                    useSsl: _connectionInfo.EnableSsl);
+                if (_connectionInfo.EnableSsl)
+                {
+                    smtpClient.Connect(
+                        _connectionInfo.MailServer, _connectionInfo.Port,
+                        useSsl: _connectionInfo.EnableSsl);
+                }
+                else
+                {
+                    smtpClient.Connect(
+                        _connectionInfo.MailServer, _connectionInfo.Port,
+                        options: SecureSocketOptions.None);
+                }
 
                 if (_connectionInfo.NetworkCredentials != null)
                 {


### PR DESCRIPTION
MailKit will throw `SslHandshakeException` when you connect using `useSsl: false`.

In order to have a completely non-secure connection over port 25, you need to use the Connect overload with `options: SecureSocketOptions.None`.

[https://stackoverflow.com/a/66066867/111266](https://stackoverflow.com/a/66066867/111266)

From [the MimeKit docs](http://www.mimekit.net/docs/html/M_MailKit_MailService_Connect_3.htm):

> The useSsl argument only controls whether or not the client makes an SSL-wrapped connection. In other words, even if the useSsl parameter is false, SSL/TLS may still be used if the mail server supports the STARTTLS extension.
> 
> To disable all use of SSL/TLS, use the Connect(String, Int32, SecureSocketOptions, CancellationToken) overload with a value of SecureSocketOptions.None instead.