### PR TITLE
Update to Serilog 4, drop `PeriodicBatchingSink` dependency

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,15 @@
 version: '{build}'
 skip_tags: true
 image: Visual Studio 2022
-test: off
 build_script:
   - pwsh: ./Build.ps1
+test: off
 artifacts:
   - path: artifacts/Serilog.*.nupkg
 deploy:
   - provider: NuGet
     api_key:
-      secure: sDnchSg4TZIOK7oIUI6BJwFPNENTOZrGNsroGO1hehLJSvlHpFmpTwiX8+bgPD+Q
+      secure: ZpUO4ECx4c/V0Ecj04cfV1UGd+ZABeEG9DDW2fjG8vITjNYhmbiiJH0qNOnRy2G3
     skip_symbols: true
     on:
       branch: /^(main|dev)$/
@@ -20,4 +20,3 @@ deploy:
     tag: v$(appveyor_build_version)
     on:
       branch: main
-

--- a/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
+++ b/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
@@ -3,8 +3,8 @@
     <Description>Send Serilog events as SMTP email using MailKit.</Description>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net462</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net462;net471</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
@@ -30,9 +30,8 @@
     <None Include="../../README.md" Pack="true" Visible="false" PackagePath="/" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="4.0.0-*" />
-    <PackageReference Include="MailKit" Version="4.3.0" />
+    <PackageReference Include="Serilog" Version="4.0.0" />
+    <PackageReference Include="MailKit" Version="4.6.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailSink.cs
@@ -16,8 +16,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Serilog.Events;
-using Serilog.Sinks.PeriodicBatching;
 using System.Linq;
+using Serilog.Core;
 
 namespace Serilog.Sinks.Email;
 
@@ -41,7 +41,7 @@ class EmailSink : IBatchedLogEventSink, IDisposable
     /// Emit a batch of log events, running asynchronously.
     /// </summary>
     /// <param name="events">The events to emit.</param>
-    public Task EmitBatchAsync(IEnumerable<LogEvent> events)
+    public Task EmitBatchAsync(IReadOnlyCollection<LogEvent> events)
     {
         // ReSharper disable PossibleMultipleEnumeration
 

--- a/test/Serilog.Sinks.Email.Tests/EmailSinkTests.cs
+++ b/test/Serilog.Sinks.Email.Tests/EmailSinkTests.cs
@@ -6,8 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Serilog.Configuration;
 using Serilog.Sinks.Email.Tests.Support;
-using Serilog.Sinks.PeriodicBatching;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -140,7 +140,7 @@ public class EmailSinkTests
         var sink = new EmailSink(emailConnectionInfo, emailTransport);
 
         using (var emailLogger = new LoggerConfiguration()
-                   .WriteTo.Sink(new PeriodicBatchingSink(sink, new PeriodicBatchingSinkOptions()))
+                   .WriteTo.Sink(sink, new BatchingOptions())
                    .CreateLogger())
         {
             emailLogger.Information("Information");

--- a/test/Serilog.Sinks.Email.Tests/Serilog.Sinks.Email.Tests.csproj
+++ b/test/Serilog.Sinks.Email.Tests/Serilog.Sinks.Email.Tests.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.4" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
The configuration API now accepts `BatchingOptions` instead of `PeriodicBatchingSinkOptions`, which is a breaking change, particularly for JSON configuration with `$type` (though this will be rare to see).