### PR TITLE
Add `EmailSinkOptions.SaslMechanism` for `OAuth2` authentication support

### DIFF
--- a/src/Serilog.Sinks.Email/Sinks/Email/EmailSinkOptions.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/EmailSinkOptions.cs
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Net;
 using MailKit.Security;
 using Serilog.Formatting;
@@ -63,7 +60,7 @@ public sealed class EmailSinkOptions
     public int Port { get; set; } = DefaultPort;
 
     /// <summary>
-    /// Gets or sets the credentials used for authentication.
+    /// Gets or sets the credentials used for authentication. See also <see cref="SaslMechanism"/> for OAuth2 credentials.
     /// </summary>
     public ICredentialsByHost? Credentials { get; set; }
 
@@ -97,4 +94,11 @@ public sealed class EmailSinkOptions
     /// Provides a method that validates server certificates.
     /// </summary>
     public System.Net.Security.RemoteCertificateValidationCallback? ServerCertificateValidationCallback { get; set; }
+
+    /// <summary>
+    /// A <see cref="MailKit.Security.SaslMechanism"/> for performing OAuth2 authentication against services such as
+    /// Microsoft 365. See <a href="https://github.com/jstedfast/MailKit/blob/master/ExchangeOAuth2.md#authenticating-a-web-service-with-oauth2">these instructions</a>
+    /// for how to create this object.
+    /// </summary>
+    public SaslMechanism? SaslMechanism { get; set; }
 }

--- a/src/Serilog.Sinks.Email/Sinks/Email/MailKitEmailTransport.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/MailKitEmailTransport.cs
@@ -32,12 +32,12 @@ class MailKitEmailTransport(EmailSinkOptions options) : IEmailTransport
             ? new BodyBuilder { HtmlBody = emailMessage.Body }.ToMessageBody()
             : new BodyBuilder { TextBody = emailMessage.Body }.ToMessageBody();
 
-        using var smtpClient = OpenConnectedSmtpClient();
+        using var smtpClient = await OpenConnectedSmtpClientAsync();
         await smtpClient.SendAsync(mimeMessage);
         await smtpClient.DisconnectAsync(quit: true);
     }
 
-    SmtpClient OpenConnectedSmtpClient()
+    async Task<SmtpClient> OpenConnectedSmtpClientAsync()
     {
         var smtpClient = new SmtpClient();
 
@@ -48,15 +48,20 @@ class MailKitEmailTransport(EmailSinkOptions options) : IEmailTransport
             smtpClient.ServerCertificateValidationCallback += options.ServerCertificateValidationCallback;
         }
 
-        smtpClient.Connect(options.Host, options.Port, options.ConnectionSecurity);
+        await smtpClient.ConnectAsync(options.Host, options.Port, options.ConnectionSecurity);
 
-        if (options.Credentials != null)
+        if (options.SaslMechanism != null)
         {
-            smtpClient.Authenticate(
+            await smtpClient.AuthenticateAsync(options.SaslMechanism);
+        }
+        else if (options.Credentials != null)
+        {
+            await smtpClient.AuthenticateAsync(
                 Encoding.UTF8,
                 options.Credentials.GetCredential(
                     options.Host, options.Port, "smtp"));
         }
+
         return smtpClient;
     }
 


### PR DESCRIPTION
Fixes #152

Usage is as shown in the SMTP instructions in https://github.com/jstedfast/MailKit/blob/master/ExchangeOAuth2.md#authenticating-a-web-service-with-oauth2

@divakaraj this is untested and needs some verification before it can be merged. If you're able to check out this branch and use the `TestHarness` project to check whether there are any issues connecting to your Microsoft 365 account with it, the validation would be great. Thanks!