### PR TITLE
Update MailKit to version 4.16.0 and fix compilation error

### DIFF
--- a/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
+++ b/src/Serilog.Sinks.Email/Serilog.Sinks.Email.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
     <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="All" />
     <PackageReference Include="Serilog" Version="4.3.1" />
-    <PackageReference Include="MailKit" Version="4.15.1" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.Email/Sinks/Email/MailKitEmailTransport.cs
+++ b/src/Serilog.Sinks.Email/Sinks/Email/MailKitEmailTransport.cs
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using MailKit.Net.Smtp;
@@ -54,12 +55,9 @@ class MailKitEmailTransport(EmailSinkOptions options) : IEmailTransport
         {
             await smtpClient.AuthenticateAsync(options.SaslMechanism);
         }
-        else if (options.Credentials != null)
+        else if (options.Credentials?.GetCredential(options.Host, options.Port, "smtp") is NetworkCredential credentials)
         {
-            await smtpClient.AuthenticateAsync(
-                Encoding.UTF8,
-                options.Credentials.GetCredential(
-                    options.Host, options.Port, "smtp"));
+            await smtpClient.AuthenticateAsync(Encoding.UTF8, credentials);
         }
 
         return smtpClient;


### PR DESCRIPTION
Bump MailKit to 4.16.0 to fix STARTTLS Response Injection vulnerability

fixes #159 